### PR TITLE
New Scenario added for Create Account using a defined Domain so that it can be tracked in DB

### DIFF
--- a/spec.js
+++ b/spec.js
@@ -4,15 +4,29 @@ const faker = require('faker');
 const CreateBlogPost = require('./page-objects/create-blog-post.po.js');
 
 describe('Choko - Create account', () => {
-  it('password not match', () => {
-    const randomEmail = faker.internet.email();
-    const randomName = faker.name.findName();
-    const randomPass1 = faker.internet.password();
-    const randomPass2 = faker.internet.password();
+  const randomEmail = faker.internet.email();
+  const randomName = faker.name.findName();
+  const randomPass1 = faker.internet.password();
+  const randomPass2 = faker.internet.password();
+  const defaultEmail = faker.internet.email(randomName, randomName, 'choko.org');
 
+  it('password not match', () => {
     browser.get('create-account');
 
     element(by.id('element-create-account-email')).sendKeys(randomEmail);
+    element(by.id('element-create-account-username')).sendKeys(randomName);
+    element(by.id('element-create-account-password')).sendKeys(randomPass1);
+    element(by.id('element-create-account-password-confirm')).sendKeys(randomPass2);
+    element(by.id('element-create-account-submit')).click();
+
+    expect(element(by.repeater('error in errors')).isDisplayed()).toBe(true);
+    expect(element(by.repeater('error in errors')).getText()).toEqual('Passwords must match.');
+  });
+
+  it('Choko - Create account', () => {
+    browser.get('create-account');
+
+    element(by.id('element-create-account-email')).sendKeys(defaultEmail);
     element(by.id('element-create-account-username')).sendKeys(randomName);
     element(by.id('element-create-account-password')).sendKeys(randomPass1);
     element(by.id('element-create-account-password-confirm')).sendKeys(randomPass2);

--- a/spec.js
+++ b/spec.js
@@ -23,7 +23,7 @@ describe('Choko - Create account', () => {
     expect(element(by.repeater('error in errors')).getText()).toEqual('Passwords must match.');
   });
 
-  it('Choko - Create account', () => {
+  it('password not match, using defaultEmail set to "choko.org"', () => {
     browser.get('create-account');
 
     element(by.id('element-create-account-email')).sendKeys(defaultEmail);


### PR DESCRIPTION
I created a new scenario for the account creation section.

The problem when using an email which is random generated is that, by running the test multiple times, it will create a new user in the DataBase, but the domain will be different each time.

This test is using the faker.internet.email() method which accepts 3 arguments: first-name, last-name, and provider. 

I am passing as first-name and last name the randomName constant (which will generate random strings for that), but setting the provider to 'choko.org'.

This means that, whenever the test will be executed, and a new user will be created, the domain will be 'choko.org', which is useful when querying the DataBase. For example, if such a test is ran in Production, in time there could be thousands of fake users, but knowing the provider ('choko.org'), those could be deleted from Production with ease just running a query to do that.
